### PR TITLE
Add test runner

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,9 +87,46 @@ test_basic_SOURCES = src/test-basic.c
 test_basic_LDADD = libfirmware.a
 
 # ------------------------------------------------------------------------------
+# test-runner
+
+if TEST_RUNNER
+test_runner_SOURCES = \
+	tools/test-runner.c
+
+libtester_a_SOURCES = \
+	tools/tester.c \
+	tools/tester.h \
+	tools/util.h \
+	tools/util.c
+libtester_a_CFLAGS = \
+	$(GLIB_CFLAGS) \
+        $(AM_CFLAGS)
+libtester_a_LDLAGS = \
+	$(GLIB_LDLAGS)
+
+firmware_tester_SOURCES = \
+	tools/firmware-tester.c
+firmware_tester_CFLAGS = \
+	$(GLIB_CFLAGS) \
+        $(AM_CFLAGS)
+firmware_tester_LDADD = \
+        libtester.a \
+	$(GLIB_LIBS)
+endif
+
+# ------------------------------------------------------------------------------
 # targets
 
 noinst_LIBRARIES = libfirmware.a
+
+if TEST_RUNNER
+noinst_LIBRARIES += \
+        libtester.a
+noinst_PROGRAMS = \
+	test-runner \
+	firmware_tester
+endif
+
 bin_PROGRAMS = firmwared
 default_tests = \
 	test-basic

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,22 @@ fi
 AM_CONDITIONAL(HAVE_LIBUDEV, [test "$have_libmount" = "yes"])
 
 # ------------------------------------------------------------------------------
+AC_ARG_ENABLE(test-runner,
+        AC_HELP_STRING([--disable-test-runner], [build test-runner for testing]),
+        [enable_test_runner=${enableval}])
+if test "x$enable_test_runner" != xno; then
+        have_glib=no
+        PKG_CHECK_MODULES(GLIB, glib-2.0 >= 2.28,
+                [AC_DEFINE(HAVE_GLIB, 1, [Define if libglib is available]) have_glib=yes], have_glib=no)
+        if test "x$have_glib" = xno; then
+                AC_MSG_ERROR([*** libglib support required but libraries not found])
+        fi
+fi
+AM_CONDITIONAL(TEST_RUNNER, [test "x$enable_test_runner" != "xno"])
+AC_SUBST(GLIB_CFLAGS)
+AC_SUBST(GLIB_LIBS)
+
+# ------------------------------------------------------------------------------
 AC_ARG_WITH(firmware-path,
         AS_HELP_STRING([--with-firmware-path=DIR[[[:DIR[...]]]]],
            [Firmware search path (default="/lib/firmware/updates:/lib/firmware")]),

--- a/src/firmwared.c
+++ b/src/firmwared.c
@@ -1,22 +1,58 @@
 #include <stdlib.h>
 #include <string.h>
+#include <getopt.h>
 
 #include "manager.h"
 #include "log-util.h"
 
+static void usage(void) {
+	printf("firmwared - Linux Firmware Loader Daemon\n"
+		"Usage:\n");
+	printf("\tfirmwared [options] [--] <command> [args]\n");
+	printf("Options:\n"
+		"\t-t, --tentative        Defer loading of non existing firmwares\n"
+		"\t-d, --dir [path]       Firmware loading path\n"
+		"\t-h, --help             Show help options\n");
+}
+
+static const struct option main_options[] = {
+	{ "tentative",     no_argument,       NULL, 't' },
+	{ "dir",           required_argument, NULL, 'd' },
+	{ "help",          no_argument,       NULL, 'h' },
+	{ }
+};
+
 int main(int argc, char **argv) {
         _cleanup_(manager_freep) Manager *manager = NULL;
         bool tentative = false;
+        const char *firmware_path = NULL;
         int r;
+
+        for (;;) {
+                int opt;
+
+                opt = getopt_long(argc, argv, "td:h", main_options, NULL);
+                if (opt < 0)
+                        break;
+
+                switch (opt) {
+                case 't':
+                        tentative = true;
+                        break;
+                case 'd':
+                        firmware_path = optarg;
+                        break;
+                case 'h':
+                        usage();
+                        return EXIT_SUCCESS;
+                default:
+                        return EXIT_FAILURE;
+                }
+        }
 
         setbuf(stdout, NULL);
 
-        for (int i = 0; i < argc; i++) {
-                if (strcmp("--tentative", argv[i]) == 0)
-                        tentative = true;
-        }
-
-        r = manager_new(&manager, tentative);
+        r = manager_new(&manager, tentative, firmware_path);
         if (r < 0) {
                 log_error("firmwared %s", strerror(-r));
                 return EXIT_FAILURE;

--- a/src/manager.h
+++ b/src/manager.h
@@ -6,7 +6,7 @@
 
 typedef struct Manager Manager;
 
-int manager_new(Manager **managerp, bool tentative);
+int manager_new(Manager **managerp, bool tentative, const char *path);
 void manager_free(Manager *manager);
 
 int manager_run(Manager *manager);

--- a/tools/firmware-tester.c
+++ b/tools/firmware-tester.c
@@ -1,0 +1,122 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "tester.h"
+
+#define TRIGGER_REQUEST "/sys/class/misc/test_firmware/trigger_request"
+#define TRIGGER_ASYNC_REQUEST "/sys/class/misc/test_firmware/trigger_async_request"
+
+struct user_data {
+        int fd;
+};
+
+static void user_data_free(void *data)
+{
+        struct user_data *user = data;
+
+        free(user);
+}
+
+#define test_load(name, setup, func, teardown) \
+        do { \
+                struct user_data *user; \
+                user = calloc(1, sizeof(struct user_data)); \
+                if (!user) \
+                        break; \
+                tester_add_full(name, NULL, \
+                                NULL, setup, func, teardown, \
+                                NULL, 2, user, user_data_free); \
+        } while (0)
+
+static void test_firmware_load(const void *test_data) {
+        struct user_data *user = tester_get_data();
+        const char *filename = "foobar.bin";
+        ssize_t len;
+
+        len = write(user->fd, filename, strlen(filename));
+        if (len < 0) {
+                tester_warn("Failed to load firmware %s: %s",
+                        filename, strerror(errno));
+                tester_test_failed();
+                return;
+        }
+        tester_test_passed();
+}
+
+static void setup_sync_load(const void *test_data) {
+        struct user_data *user = tester_get_data();
+
+        user->fd = open(TRIGGER_REQUEST, O_CLOEXEC|O_WRONLY);
+        if (user->fd < 0) {
+                tester_warn("Failed to open %s: %s", TRIGGER_REQUEST,
+                        strerror(errno));
+                tester_setup_failed();
+                return;
+        }
+
+        tester_setup_complete();
+}
+
+static void setup_async_load(const void *test_data) {
+        struct user_data *user = tester_get_data();
+
+        user->fd = open(TRIGGER_ASYNC_REQUEST, O_CLOEXEC|O_WRONLY);
+        if (user->fd < 0) {
+                tester_warn("Failed to open %s: %s", TRIGGER_ASYNC_REQUEST,
+                        strerror(errno));
+                tester_setup_failed();
+                return;
+        }
+        tester_setup_complete();
+}
+
+static void teardown_load(const void *test_data) {
+        struct user_data *user = tester_get_data();
+
+        close(user->fd);
+        tester_teardown_complete();
+}
+
+static void create_firmware() {
+        const char *data = "narf";
+        ssize_t len;
+        int fd;
+
+        fd = open("/tmp/foobar.bin", O_CLOEXEC|O_CREAT|O_WRONLY, 0x444);
+        if (fd < 0) {
+                tester_warn("Failed to create firmware: %s",
+                        strerror(errno));
+                tester_test_failed();
+                return;
+        }
+
+        len = write(fd, data, strlen(data));
+        if (len < 0) {
+                tester_warn("Failed to write content to firmware file: %s",
+                        strerror(errno));
+                tester_test_failed();
+                close(fd);
+                return;
+        }
+        close(fd);
+        tester_test_passed();
+}
+
+int main(int argc, char *argv[]) {
+
+        tester_init(&argc, &argv);
+
+        test_load("Create firmware", NULL, create_firmware, NULL);
+
+        test_load("Load firmware", setup_sync_load, test_firmware_load, teardown_load);
+        test_load("Load firmware async", setup_async_load, test_firmware_load, teardown_load);
+
+        return tester_run();
+}

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -1,0 +1,608 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <string.h>
+#include <getopt.h>
+#include <poll.h>
+#include <stdint.h>
+#include <termios.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/mount.h>
+#include <sys/param.h>
+#include <sys/reboot.h>
+
+#ifndef WAIT_ANY
+#define WAIT_ANY (-1)
+#endif
+
+#define CMDLINE_MAX 2048
+
+static const char *own_binary;
+static char **test_argv;
+static int test_argc;
+
+static bool run_auto = false;
+static const char *qemu_binary = NULL;
+static const char *kernel_image = NULL;
+
+static const char *qemu_table[] = {
+        "qemu-system-x86_64",
+        "qemu-system-i386",
+        "/usr/bin/qemu-system-x86_64",
+        "/usr/bin/qemu-system-i386",
+        NULL
+};
+
+static const char *find_qemu(void)
+{
+        int i;
+
+        for (i = 0; qemu_table[i]; i++) {
+                struct stat st;
+
+                if (!stat(qemu_table[i], &st))
+                        return qemu_table[i];
+        }
+
+        return NULL;
+}
+
+static const char *kernel_table[] = {
+        "bzImage",
+        "arch/x86/boot/bzImage",
+        "vmlinux",
+        "arch/x86/boot/vmlinux",
+        NULL
+};
+
+static const char *find_kernel(void)
+{
+        int i;
+
+        for (i = 0; kernel_table[i]; i++) {
+                struct stat st;
+
+                if (!stat(kernel_table[i], &st))
+                        return kernel_table[i];
+        }
+
+        return NULL;
+}
+
+static const struct {
+        const char *target;
+        const char *linkpath;
+} dev_table[] = {
+        { "/proc/self/fd",      "/dev/fd"       },
+        { "/proc/self/fd/0",    "/dev/stdin"    },
+        { "/proc/self/fd/1",    "/dev/stdout"   },
+        { "/proc/self/fd/2",    "/dev/stderr"   },
+        { }
+};
+
+static const struct {
+        const char *fstype;
+        const char *target;
+        const char *options;
+        unsigned long flags;
+} mount_table[] = {
+        { "sysfs",    "/sys",     NULL,        MS_NOSUID|MS_NOEXEC|MS_NODEV },
+        { "proc",     "/proc",    NULL,        MS_NOSUID|MS_NOEXEC|MS_NODEV },
+        { "devtmpfs", "/dev",     "mode=0755", MS_NOSUID|MS_STRICTATIME },
+        { "devpts",   "/dev/pts", "mode=0620", MS_NOSUID|MS_NOEXEC },
+        { "tmpfs",    "/dev/shm", "mode=1777", MS_NOSUID|MS_NODEV|MS_STRICTATIME },
+        { "tmpfs",    "/run",     "mode=0755", MS_NOSUID|MS_NODEV|MS_STRICTATIME },
+        { "tmpfs",    "/tmp",              NULL, 0 },
+        { "debugfs",  "/sys/kernel/debug", NULL, 0 },
+        { }
+};
+
+static const char *config_table[] = {
+        "/lib/firmware/updates",
+        "/lib/firmware",
+        "/tmp",
+        NULL
+};
+
+static void prepare_sandbox(void)
+{
+        int i;
+
+        for (i = 0; mount_table[i].fstype; i++) {
+                struct stat st;
+
+                if (lstat(mount_table[i].target, &st) < 0) {
+                        printf("Creating %s\n", mount_table[i].target);
+                        mkdir(mount_table[i].target, 0755);
+                }
+
+                printf("Mounting %s to %s\n", mount_table[i].fstype,
+                                                mount_table[i].target);
+
+                if (mount(mount_table[i].fstype,
+                                mount_table[i].target,
+                                mount_table[i].fstype,
+                                mount_table[i].flags,
+                                mount_table[i].options) < 0)
+                        perror("Failed to mount filesystem");
+        }
+
+        for (i = 0; dev_table[i].target; i++) {
+                printf("Linking %s to %s\n", dev_table[i].linkpath,
+                                                dev_table[i].target);
+
+                if (symlink(dev_table[i].target, dev_table[i].linkpath) < 0)
+                        perror("Failed to create device symlink");
+        }
+
+        printf("Creating new session group leader\n");
+        setsid();
+
+        printf("Setting controlling terminal\n");
+        ioctl(STDIN_FILENO, TIOCSCTTY, 1);
+
+        for (i = 0; config_table[i]; i++) {
+                printf("Creating %s\n", config_table[i]);
+
+                if (mount("tmpfs", config_table[i], "tmpfs",
+                                MS_NOSUID|MS_NOEXEC|MS_NODEV|MS_STRICTATIME,
+                                "mode=0755") < 0)
+                        perror("Failed to create filesystem");
+        }
+}
+
+static char *const qemu_argv[] = {
+        "",
+        "-nodefaults",
+        "-nodefconfig",
+        "-no-user-config",
+        "-monitor", "none",
+        "-display", "none",
+        "-machine", "type=q35,accel=kvm:tcg",
+        "-m", "192M",
+        "-nographic",
+        "-vga", "none",
+        "-net", "none",
+        "-balloon", "none",
+        "-no-acpi",
+        "-no-hpet",
+        "-no-reboot",
+        "-fsdev", "local,id=fsdev-root,path=/,readonly,security_model=none",
+        "-device", "virtio-9p-pci,fsdev=fsdev-root,mount_tag=/dev/root",
+        "-chardev", "stdio,id=chardev-serial0,signal=off",
+        "-device", "pci-serial,chardev=chardev-serial0",
+        NULL
+};
+
+static char *const qemu_envp[] = {
+        "HOME=/",
+        NULL
+};
+
+static void check_virtualization(void)
+{
+#if defined(__GNUC__) && (defined(__i386__) || defined(__amd64__))
+        uint32_t ecx;
+
+        __asm__ __volatile__("cpuid" : "=c" (ecx) : "a" (1) : "memory");
+
+        if (!!(ecx & (1 << 5)))
+                printf("Found support for Virtual Machine eXtensions\n");
+#endif
+}
+
+static void start_qemu(void)
+{
+        char cwd[PATH_MAX], initcmd[PATH_MAX], testargs[PATH_MAX];
+        char cmdline[CMDLINE_MAX];
+        char **argv;
+        int i, pos;
+
+        check_virtualization();
+
+        if (!getcwd(cwd, sizeof(cwd)))
+                strcat(cwd, "/");
+
+        if (own_binary[0] == '/')
+                snprintf(initcmd, sizeof(initcmd), "%s", own_binary);
+        else
+                snprintf(initcmd, sizeof(initcmd), "%s/%s", cwd, own_binary);
+
+        pos = snprintf(testargs, sizeof(testargs), "%s", test_argv[0]);
+
+        for (i = 1; i < test_argc; i++) {
+                int len = sizeof(testargs) - pos;
+                pos += snprintf(testargs + pos, len, " %s", test_argv[i]);
+        }
+
+        snprintf(cmdline, sizeof(cmdline),
+                                "console=ttyS0,115200n8 earlyprintk=serial "
+                                "rootfstype=9p "
+                                "rootflags=trans=virtio,version=9p2000.L "
+                                "acpi=off pci=noacpi noapic quiet ro init=%s "
+                                "TESTHOME=%s "
+                                "TESTAUTO=%u TESTARGS=\'%s\'", initcmd, cwd,
+                                run_auto, testargs);
+
+        argv = alloca(sizeof(qemu_argv) + (sizeof(char *) * 4));
+        memcpy(argv, qemu_argv, sizeof(qemu_argv));
+
+        pos = (sizeof(qemu_argv) / sizeof(char *)) - 1;
+
+        argv[0] = (char *) qemu_binary;
+
+        argv[pos++] = "-kernel";
+        argv[pos++] = (char *) kernel_image;
+        argv[pos++] = "-append";
+        argv[pos++] = (char *) cmdline;
+        argv[pos] = NULL;
+
+        execve(argv[0], argv, qemu_envp);
+}
+
+static const char *daemon_table[] = {
+        "firmwared",
+        "/usr/sbin/firmwared",
+        NULL
+};
+
+static pid_t start_firmware_daemon(const char *home)
+{
+        const char *daemon = NULL;
+        char *argv[4], *envp[1];
+        pid_t pid;
+        int i;
+
+        if (chdir(home + 5) < 0) {
+                perror("Failed to change home directory for daemon");
+                return -1;
+        }
+
+        for (i = 0; daemon_table[i]; i++) {
+                struct stat st;
+
+                if (!stat(daemon_table[i], &st)) {
+                        daemon = daemon_table[i];
+                        break;
+                }
+        }
+
+        if (!daemon) {
+                fprintf(stderr, "Failed to locate firmware daemon binary\n");
+                return -1;
+        }
+
+        printf("Using firmware daemon %s\n", daemon);
+
+        argv[0] = (char *) daemon;
+        argv[1] = (char *) "--dir";
+        argv[2] = (char *) "/tmp";
+        argv[3] = NULL;
+
+        envp[0] = NULL;
+
+        printf("Starting firmware daemon\n");
+
+        pid = fork();
+        if (pid < 0) {
+                perror("Failed to fork new process");
+                return -1;
+        }
+
+        if (pid == 0) {
+                execve(argv[0], argv, envp);
+                exit(EXIT_SUCCESS);
+        }
+
+        printf("firmware daemon process %d created\n", pid);
+
+        return pid;
+}
+
+static const char *test_table[] = {
+        "firmware_tester",
+        NULL
+};
+
+static void run_command(char *cmdname, char *home)
+{
+        char *argv[9], *envp[3];
+        int pos = 0, idx = 0;
+        pid_t pid, daemon_pid;
+
+        daemon_pid = start_firmware_daemon(home);
+
+start_next:
+        if (run_auto) {
+                if (chdir(home + 5) < 0) {
+                        perror("Failed to change home test directory");
+                        return;
+                }
+
+                while (1) {
+                        struct stat st;
+
+                        if (!test_table[idx])
+                                return;
+
+                        if (!stat(test_table[idx], &st))
+                                break;
+
+                        idx++;
+                }
+
+                argv[0] = (char *) test_table[idx];
+                argv[1] = "-q";
+                argv[2] = NULL;
+        } else {
+                while (1) {
+                        char *ptr;
+
+                        ptr = strchr(cmdname, ' ');
+                        if (!ptr) {
+                                argv[pos++] = cmdname;
+                                break;
+                        }
+
+                        *ptr = '\0';
+                        argv[pos++] = cmdname;
+                        if (pos > 8)
+                                break;
+
+                        cmdname = ptr + 1;
+                }
+
+                argv[pos] = NULL;
+        }
+
+        pos = 0;
+        envp[pos++] = "TERM=linux";
+        if (home)
+                envp[pos++] = home;
+        envp[pos] = NULL;
+
+        printf("Running command %s\n", argv[0]);
+
+        pid = fork();
+        if (pid < 0) {
+                perror("Failed to fork new process");
+                return;
+        }
+
+        if (pid == 0) {
+                if (home) {
+                        printf("Changing into directory %s\n", home + 5);
+                        if (chdir(home + 5) < 0)
+                                perror("Failed to change directory");
+                }
+
+                execve(argv[0], argv, envp);
+                exit(EXIT_SUCCESS);
+        }
+
+        printf("New process %d created\n", pid);
+
+        while (1)  {
+                pid_t corpse;
+                int status;
+
+                corpse = waitpid(WAIT_ANY, &status, 0);
+                if (corpse < 0 || corpse == 0)
+                        continue;
+
+                if (WIFEXITED(status))
+                        printf("Process %d exited with status %d\n",
+                                                corpse, WEXITSTATUS(status));
+                else if (WIFSIGNALED(status))
+                        printf("Process %d terminated with signal %d\n",
+                                                corpse, WTERMSIG(status));
+                else if (WIFSTOPPED(status))
+                        printf("Process %d stopped with signal %d\n",
+                                                corpse, WSTOPSIG(status));
+                else if (WIFCONTINUED(status))
+                        printf("Process %d continued\n", corpse);
+
+                if (corpse == daemon_pid) {
+                        printf("firmware daemon terminated\n");
+                        daemon_pid = -1;
+                }
+
+                if (corpse == pid) {
+                        if (!run_auto) {
+                                if (daemon_pid > 0)
+                                        kill(daemon_pid, SIGTERM);
+                        }
+                        break;
+                }
+        }
+
+        if (run_auto) {
+                idx++;
+                goto start_next;
+        }
+}
+
+static void run_tests(void)
+{
+        char cmdline[CMDLINE_MAX], *ptr, *cmds, *home = NULL;
+        FILE *fp;
+
+        fp = fopen("/proc/cmdline", "re");
+        if (!fp) {
+                fprintf(stderr, "Failed to open kernel command line\n");
+                return;
+        }
+
+        ptr = fgets(cmdline, sizeof(cmdline), fp);
+        fclose(fp);
+
+        if (!ptr) {
+                fprintf(stderr, "Failed to read kernel command line\n");
+                return;
+        }
+
+        ptr = strstr(cmdline, "TESTARGS=");
+        if (!ptr) {
+                fprintf(stderr, "No test command section found\n");
+                return;
+        }
+
+        cmds = ptr + 10;
+        ptr = strchr(cmds, '\'');
+        if (!ptr) {
+                fprintf(stderr, "Malformed test command section\n");
+                return;
+        }
+
+        *ptr = '\0';
+
+        ptr = strstr(cmdline, "TESTAUTO=1");
+        if (ptr) {
+                printf("Automatic test execution requested\n");
+                run_auto= true;
+        }
+
+        ptr = strstr(cmdline, "TESTHOME=");
+        if (ptr) {
+                home = ptr + 4;
+                ptr = strpbrk(home + 9, " \r\n");
+                if (ptr)
+                        *ptr = '\0';
+        }
+
+        run_command(cmds, home);
+}
+
+static void usage(void)
+{
+        printf("test-runner - Automated test execution utility\n"
+                "Usage:\n");
+        printf("\ttest-runner [options] [--] <command> [args]\n");
+        printf("Options:\n"
+                "\t-a, --auto             Find tests and run them\n"
+                "\t-q, --qemu <path>      QEMU binary\n"
+                "\t-k, --kernel <image>   Kernel image (bzImage)\n"
+                "\t-h, --help             Show help options\n");
+}
+
+static const struct option main_options[] = {
+        { "all",     no_argument,       NULL, 'a' },
+        { "auto",    no_argument,       NULL, 'a' },
+        { "qemu",    required_argument, NULL, 'q' },
+        { "kernel",  required_argument, NULL, 'k' },
+        { "version", no_argument,       NULL, 'v' },
+        { "help",    no_argument,       NULL, 'h' },
+        { }
+};
+
+int main(int argc, char *argv[])
+{
+        if (getpid() == 1 && getppid() == 0) {
+                prepare_sandbox();
+                run_tests();
+
+                sync();
+                reboot(RB_AUTOBOOT);
+                return EXIT_SUCCESS;
+        }
+
+        for (;;) {
+                int opt;
+
+                opt = getopt_long(argc, argv, "aq:k:vh", main_options, NULL);
+                if (opt < 0)
+                        break;
+
+                switch (opt) {
+                case 'a':
+                        run_auto = true;
+                        break;
+                case 'q':
+                        qemu_binary = optarg;
+                        break;
+                case 'k':
+                        kernel_image = optarg;
+                        break;
+                case 'v':
+                        printf("%s\n", VERSION);
+                        return EXIT_SUCCESS;
+                case 'h':
+                        usage();
+                        return EXIT_SUCCESS;
+                default:
+                        return EXIT_FAILURE;
+                }
+        }
+
+        if (run_auto) {
+                if (argc - optind > 0) {
+                        fprintf(stderr, "Invalid command line parameters\n");
+                        return EXIT_FAILURE;
+                }
+        } else {
+                if (argc - optind < 1) {
+                        fprintf(stderr, "Failed to specify test command\n");
+                        return EXIT_FAILURE;
+                }
+        }
+
+        own_binary = argv[0];
+        test_argv = argv + optind;
+        test_argc = argc - optind;
+
+        if (!qemu_binary) {
+                qemu_binary = find_qemu();
+                if (!qemu_binary) {
+                        fprintf(stderr, "No default QEMU binary found\n");
+                        return EXIT_FAILURE;
+                }
+        }
+
+        if (!kernel_image) {
+                kernel_image = find_kernel();
+                if (!kernel_image) {
+                        fprintf(stderr, "No default kernel image found\n");
+                        return EXIT_FAILURE;
+                }
+        }
+
+        printf("Using QEMU binary %s\n", qemu_binary);
+        printf("Using kernel image %s\n", kernel_image);
+
+        start_qemu();
+
+        return EXIT_SUCCESS;
+}

--- a/tools/tester.c
+++ b/tools/tester.c
@@ -1,0 +1,841 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/signalfd.h>
+
+#include <glib.h>
+
+#ifdef HAVE_VALGRIND_MEMCHECK_H
+#include <valgrind/memcheck.h>
+#endif
+
+#include "util.h"
+#include "tester.h"
+
+#define COLOR_OFF       "\x1B[0m"
+#define COLOR_BLACK     "\x1B[0;30m"
+#define COLOR_RED       "\x1B[0;31m"
+#define COLOR_GREEN     "\x1B[0;32m"
+#define COLOR_YELLOW    "\x1B[0;33m"
+#define COLOR_BLUE      "\x1B[0;34m"
+#define COLOR_MAGENTA   "\x1B[0;35m"
+#define COLOR_CYAN      "\x1B[0;36m"
+#define COLOR_WHITE     "\x1B[0;37m"
+#define COLOR_HIGHLIGHT "\x1B[1;39m"
+
+#define print_text(color, fmt, args...) \
+                printf(color fmt COLOR_OFF "\n", ## args)
+
+#define print_summary(label, color, value, fmt, args...) \
+                        printf("%-52s " color "%-10s" COLOR_OFF fmt "\n", \
+                                                        label, value, ## args)
+
+#define print_progress(name, color, fmt, args...) \
+                printf(COLOR_HIGHLIGHT "%s" COLOR_OFF " - " \
+                                color fmt COLOR_OFF "\n", name, ## args)
+
+enum test_result {
+        TEST_RESULT_NOT_RUN,
+        TEST_RESULT_PASSED,
+        TEST_RESULT_FAILED,
+        TEST_RESULT_TIMED_OUT,
+};
+
+enum test_stage {
+        TEST_STAGE_INVALID,
+        TEST_STAGE_PRE_SETUP,
+        TEST_STAGE_SETUP,
+        TEST_STAGE_RUN,
+        TEST_STAGE_TEARDOWN,
+        TEST_STAGE_POST_TEARDOWN,
+};
+
+struct test_case {
+        char *name;
+        enum test_result result;
+        enum test_stage stage;
+        const void *test_data;
+        tester_data_func_t pre_setup_func;
+        tester_data_func_t setup_func;
+        tester_data_func_t test_func;
+        tester_data_func_t teardown_func;
+        tester_data_func_t post_teardown_func;
+        gdouble start_time;
+        gdouble end_time;
+        unsigned int timeout;
+        unsigned int timeout_id;
+        unsigned int teardown_id;
+        tester_destroy_func_t destroy;
+        void *user_data;
+};
+
+static GMainLoop *main_loop;
+
+static GList *test_list;
+static GList *test_current;
+static GTimer *test_timer;
+
+static gboolean option_version = FALSE;
+static gboolean option_quiet = FALSE;
+static gboolean option_debug = FALSE;
+static gboolean option_list = FALSE;
+static const char *option_prefix = NULL;
+
+static void test_destroy(gpointer data)
+{
+        struct test_case *test = data;
+
+        if (test->timeout_id > 0)
+                g_source_remove(test->timeout_id);
+
+        if (test->teardown_id > 0)
+                g_source_remove(test->teardown_id);
+
+        if (test->destroy)
+                test->destroy(test->user_data);
+
+        free(test->name);
+        free(test);
+}
+
+void tester_print(const char *format, ...)
+{
+        va_list ap;
+
+        if (tester_use_quiet())
+                return;
+
+        printf("  %s", COLOR_WHITE);
+        va_start(ap, format);
+        vprintf(format, ap);
+        va_end(ap);
+        printf("%s\n", COLOR_OFF);
+}
+
+void tester_debug(const char *format, ...)
+{
+        va_list ap;
+
+        if (!tester_use_debug())
+                return;
+
+        printf("  %s", COLOR_WHITE);
+        va_start(ap, format);
+        vprintf(format, ap);
+        va_end(ap);
+        printf("%s\n", COLOR_OFF);
+}
+
+void tester_warn(const char *format, ...)
+{
+        va_list ap;
+
+        printf("  %s", COLOR_WHITE);
+        va_start(ap, format);
+        vprintf(format, ap);
+        va_end(ap);
+        printf("%s\n", COLOR_OFF);
+}
+
+static void default_pre_setup(const void *test_data)
+{
+        tester_pre_setup_complete();
+}
+
+static void default_setup(const void *test_data)
+{
+        tester_setup_complete();
+}
+
+static void default_teardown(const void *test_data)
+{
+        tester_teardown_complete();
+}
+
+static void default_post_teardown(const void *test_data)
+{
+        tester_post_teardown_complete();
+}
+
+void tester_add_full(const char *name, const void *test_data,
+                                tester_data_func_t pre_setup_func,
+                                tester_data_func_t setup_func,
+                                tester_data_func_t test_func,
+                                tester_data_func_t teardown_func,
+                                tester_data_func_t post_teardown_func,
+                                unsigned int timeout,
+                                void *user_data, tester_destroy_func_t destroy)
+{
+        struct test_case *test;
+
+        if (!test_func)
+                return;
+
+        if (option_prefix && !g_str_has_prefix(name, option_prefix)) {
+                if (destroy)
+                        destroy(user_data);
+                return;
+        }
+
+        if (option_list) {
+                printf("%s\n", name);
+                if (destroy)
+                        destroy(user_data);
+                return;
+        }
+
+        test = new0(struct test_case, 1);
+        test->name = strdup(name);
+        test->result = TEST_RESULT_NOT_RUN;
+        test->stage = TEST_STAGE_INVALID;
+
+        test->test_data = test_data;
+
+        if (pre_setup_func)
+                test->pre_setup_func = pre_setup_func;
+        else
+                test->pre_setup_func = default_pre_setup;
+
+        if (setup_func)
+                test->setup_func = setup_func;
+        else
+                test->setup_func = default_setup;
+
+        test->test_func = test_func;
+
+        if (teardown_func)
+                test->teardown_func = teardown_func;
+        else
+                test->teardown_func = default_teardown;
+
+        if (post_teardown_func)
+                test->post_teardown_func = post_teardown_func;
+        else
+                test->post_teardown_func = default_post_teardown;
+
+        test->timeout = timeout;
+
+        test->destroy = destroy;
+        test->user_data = user_data;
+
+        test_list = g_list_append(test_list, test);
+}
+
+void tester_add(const char *name, const void *test_data,
+                                        tester_data_func_t setup_func,
+                                        tester_data_func_t test_func,
+                                        tester_data_func_t teardown_func)
+{
+        tester_add_full(name, test_data, NULL, setup_func, test_func,
+                                        teardown_func, NULL, 0, NULL, NULL);
+}
+
+void *tester_get_data(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return NULL;
+
+        test = test_current->data;
+
+        return test->user_data;
+}
+
+static int tester_summarize(void)
+{
+        unsigned int not_run = 0, passed = 0, failed = 0;
+        gdouble execution_time;
+        GList *list;
+
+        printf("\n");
+        print_text(COLOR_HIGHLIGHT, "");
+        print_text(COLOR_HIGHLIGHT, "Test Summary");
+        print_text(COLOR_HIGHLIGHT, "------------");
+
+        for (list = g_list_first(test_list); list; list = g_list_next(list)) {
+                struct test_case *test = list->data;
+                gdouble exec_time;
+
+                exec_time = test->end_time - test->start_time;
+
+                switch (test->result) {
+                case TEST_RESULT_NOT_RUN:
+                        print_summary(test->name, COLOR_YELLOW, "Not Run", "");
+                        not_run++;
+                        break;
+                case TEST_RESULT_PASSED:
+                        print_summary(test->name, COLOR_GREEN, "Passed",
+                                                "%8.3f seconds", exec_time);
+                        passed++;
+                        break;
+                case TEST_RESULT_FAILED:
+                        print_summary(test->name, COLOR_RED, "Failed",
+                                                "%8.3f seconds", exec_time);
+                        failed++;
+                        break;
+                case TEST_RESULT_TIMED_OUT:
+                        print_summary(test->name, COLOR_RED, "Timed out",
+                                                "%8.3f seconds", exec_time);
+                        failed++;
+                        break;
+                }
+        }
+
+        printf("\nTotal: %d, "
+                COLOR_GREEN "Passed: %d (%.1f%%)" COLOR_OFF ", "
+                COLOR_RED "Failed: %d" COLOR_OFF ", "
+                COLOR_YELLOW "Not Run: %d" COLOR_OFF "\n",
+                        not_run + passed + failed, passed,
+                        (not_run + passed + failed) ?
+                        (float) passed * 100 / (not_run + passed + failed) : 0,
+                        failed, not_run);
+
+        execution_time = g_timer_elapsed(test_timer, NULL);
+        printf("Overall execution time: %.3g seconds\n", execution_time);
+
+        return failed;
+}
+
+static gboolean teardown_callback(gpointer user_data)
+{
+        struct test_case *test = user_data;
+
+        test->teardown_id = 0;
+        test->stage = TEST_STAGE_TEARDOWN;
+
+        print_progress(test->name, COLOR_MAGENTA, "teardown");
+        test->teardown_func(test->test_data);
+
+#ifdef HAVE_VALGRIND_MEMCHECK_H
+        VALGRIND_DO_ADDED_LEAK_CHECK;
+#endif
+
+        return FALSE;
+}
+
+static gboolean test_timeout(gpointer user_data)
+{
+        struct test_case *test = user_data;
+
+        test->timeout_id = 0;
+
+        if (!test_current)
+                return FALSE;
+
+        test->result = TEST_RESULT_TIMED_OUT;
+        print_progress(test->name, COLOR_RED, "test timed out");
+
+        g_idle_add(teardown_callback, test);
+
+        return FALSE;
+}
+
+static void next_test_case(void)
+{
+        struct test_case *test;
+
+        if (test_current)
+                test_current = g_list_next(test_current);
+        else
+                test_current = test_list;
+
+        if (!test_current) {
+                g_timer_stop(test_timer);
+
+                g_main_loop_quit(main_loop);
+                return;
+        }
+
+        test = test_current->data;
+
+        printf("\n");
+        print_progress(test->name, COLOR_BLACK, "init");
+
+        test->start_time = g_timer_elapsed(test_timer, NULL);
+
+        if (test->timeout > 0)
+                test->timeout_id = g_timeout_add_seconds(test->timeout,
+                                                        test_timeout, test);
+
+        test->stage = TEST_STAGE_PRE_SETUP;
+
+        test->pre_setup_func(test->test_data);
+}
+
+static gboolean setup_callback(gpointer user_data)
+{
+        struct test_case *test = user_data;
+
+        test->stage = TEST_STAGE_SETUP;
+
+        print_progress(test->name, COLOR_BLUE, "setup");
+        test->setup_func(test->test_data);
+
+        return FALSE;
+}
+
+static gboolean run_callback(gpointer user_data)
+{
+        struct test_case *test = user_data;
+
+        test->stage = TEST_STAGE_RUN;
+
+        print_progress(test->name, COLOR_BLACK, "run");
+        test->test_func(test->test_data);
+
+        return FALSE;
+}
+
+static gboolean done_callback(gpointer user_data)
+{
+        struct test_case *test = user_data;
+
+        test->end_time = g_timer_elapsed(test_timer, NULL);
+
+        print_progress(test->name, COLOR_BLACK, "done");
+        next_test_case();
+
+        return FALSE;
+}
+
+void tester_pre_setup_complete(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_PRE_SETUP)
+                return;
+
+        g_idle_add(setup_callback, test);
+}
+
+void tester_pre_setup_failed(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_PRE_SETUP)
+                return;
+
+        print_progress(test->name, COLOR_RED, "pre setup failed");
+
+        g_idle_add(done_callback, test);
+}
+
+void tester_setup_complete(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_SETUP)
+                return;
+
+        print_progress(test->name, COLOR_BLUE, "setup complete");
+
+        g_idle_add(run_callback, test);
+}
+
+void tester_setup_failed(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_SETUP)
+                return;
+
+        test->stage = TEST_STAGE_POST_TEARDOWN;
+
+        if (test->timeout_id > 0) {
+                g_source_remove(test->timeout_id);
+                test->timeout_id = 0;
+        }
+
+        print_progress(test->name, COLOR_RED, "setup failed");
+        print_progress(test->name, COLOR_MAGENTA, "teardown");
+
+        test->post_teardown_func(test->test_data);
+}
+
+static void test_result(enum test_result result)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_RUN)
+                return;
+
+        if (test->timeout_id > 0) {
+                g_source_remove(test->timeout_id);
+                test->timeout_id = 0;
+        }
+
+        test->result = result;
+        switch (result) {
+        case TEST_RESULT_PASSED:
+                print_progress(test->name, COLOR_GREEN, "test passed");
+                break;
+        case TEST_RESULT_FAILED:
+                print_progress(test->name, COLOR_RED, "test failed");
+                break;
+        case TEST_RESULT_NOT_RUN:
+                print_progress(test->name, COLOR_YELLOW, "test not run");
+                break;
+        case TEST_RESULT_TIMED_OUT:
+                print_progress(test->name, COLOR_RED, "test timed out");
+                break;
+        }
+
+        if (test->teardown_id > 0)
+                return;
+
+        test->teardown_id = g_idle_add(teardown_callback, test);
+}
+
+void tester_test_passed(void)
+{
+        test_result(TEST_RESULT_PASSED);
+}
+
+void tester_test_failed(void)
+{
+        test_result(TEST_RESULT_FAILED);
+}
+
+void tester_test_abort(void)
+{
+        test_result(TEST_RESULT_NOT_RUN);
+}
+
+void tester_teardown_complete(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_TEARDOWN)
+                return;
+
+        test->stage = TEST_STAGE_POST_TEARDOWN;
+
+        test->post_teardown_func(test->test_data);
+}
+
+void tester_teardown_failed(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_TEARDOWN)
+                return;
+
+        test->stage = TEST_STAGE_POST_TEARDOWN;
+
+        tester_post_teardown_failed();
+}
+
+void tester_post_teardown_complete(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_POST_TEARDOWN)
+                return;
+
+        print_progress(test->name, COLOR_MAGENTA, "teardown complete");
+
+        g_idle_add(done_callback, test);
+}
+
+void tester_post_teardown_failed(void)
+{
+        struct test_case *test;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        if (test->stage != TEST_STAGE_POST_TEARDOWN)
+                return;
+
+        print_progress(test->name, COLOR_RED, "teardown failed");
+
+        g_idle_add(done_callback, test);
+}
+
+static gboolean start_tester(gpointer user_data)
+{
+        test_timer = g_timer_new();
+
+        next_test_case();
+
+        return FALSE;
+}
+
+struct wait_data {
+        unsigned int seconds;
+        struct test_case *test;
+        tester_wait_func_t func;
+        void *user_data;
+};
+
+static gboolean wait_callback(gpointer user_data)
+{
+        struct wait_data *wait = user_data;
+        struct test_case *test = wait->test;
+
+        wait->seconds--;
+
+        if (wait->seconds > 0) {
+                print_progress(test->name, COLOR_BLACK, "%u seconds left",
+                                                                wait->seconds);
+                return TRUE;
+        }
+
+        print_progress(test->name, COLOR_BLACK, "waiting done");
+
+        wait->func(wait->user_data);
+
+        free(wait);
+
+        return FALSE;
+}
+
+void tester_wait(unsigned int seconds, tester_wait_func_t func,
+                                                        void *user_data)
+{
+        struct test_case *test;
+        struct wait_data *wait;
+
+        if (!func || seconds < 1)
+                return;
+
+        if (!test_current)
+                return;
+
+        test = test_current->data;
+
+        wait = new0(struct wait_data, 1);
+        wait->seconds = seconds;
+        wait->test = test;
+        wait->func = func;
+        wait->user_data = user_data;
+
+        g_timeout_add(1000, wait_callback, wait);
+
+        print_progress(test->name, COLOR_BLACK, "waiting %u seconds", seconds);
+}
+
+static gboolean signal_handler(GIOChannel *channel, GIOCondition condition,
+                                                        gpointer user_data)
+{
+        static bool terminated = false;
+        struct signalfd_siginfo si;
+        ssize_t result;
+        int fd;
+
+        if (condition & (G_IO_NVAL | G_IO_ERR | G_IO_HUP)) {
+                g_main_loop_quit(main_loop);
+                return FALSE;
+        }
+
+        fd = g_io_channel_unix_get_fd(channel);
+
+        result = read(fd, &si, sizeof(si));
+        if (result != sizeof(si))
+                return FALSE;
+
+        switch (si.ssi_signo) {
+        case SIGINT:
+        case SIGTERM:
+                if (!terminated)
+                        g_main_loop_quit(main_loop);
+
+                terminated = true;
+                break;
+        }
+
+        return TRUE;
+}
+
+static guint setup_signalfd(void)
+{
+        GIOChannel *channel;
+        guint source;
+        sigset_t mask;
+        int fd;
+
+        sigemptyset(&mask);
+        sigaddset(&mask, SIGINT);
+        sigaddset(&mask, SIGTERM);
+
+        if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0) {
+                perror("Failed to set signal mask");
+                return 0;
+        }
+
+        fd = signalfd(-1, &mask, 0);
+        if (fd < 0) {
+                perror("Failed to create signal descriptor");
+                return 0;
+        }
+
+        channel = g_io_channel_unix_new(fd);
+
+        g_io_channel_set_close_on_unref(channel, TRUE);
+        g_io_channel_set_encoding(channel, NULL, NULL);
+        g_io_channel_set_buffered(channel, FALSE);
+
+        source = g_io_add_watch(channel,
+                                G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL,
+                                signal_handler, NULL);
+
+        g_io_channel_unref(channel);
+
+        return source;
+}
+
+bool tester_use_quiet(void)
+{
+        return option_quiet == TRUE ? true : false;
+}
+
+bool tester_use_debug(void)
+{
+        return option_debug == TRUE ? true : false;
+}
+
+static GOptionEntry options[] = {
+        { "version", 'v', 0, G_OPTION_ARG_NONE, &option_version,
+                                "Show version information and exit" },
+        { "quiet", 'q', 0, G_OPTION_ARG_NONE, &option_quiet,
+                                "Run tests without logging" },
+        { "debug", 'd', 0, G_OPTION_ARG_NONE, &option_debug,
+                                "Run tests with debug output" },
+        { "list", 'l', 0, G_OPTION_ARG_NONE, &option_list,
+                                "Only list the tests to be run" },
+        { "prefix", 'p', 0, G_OPTION_ARG_STRING, &option_prefix,
+                                "Run tests matching provided prefix" },
+        { NULL },
+};
+
+void tester_init(int *argc, char ***argv)
+{
+        GOptionContext *context;
+        GError *error = NULL;
+
+        context = g_option_context_new(NULL);
+        g_option_context_add_main_entries(context, options, NULL);
+
+        if (g_option_context_parse(context, argc, argv, &error) == FALSE) {
+                if (error != NULL) {
+                        g_printerr("%s\n", error->message);
+                        g_error_free(error);
+                } else
+                        g_printerr("An unknown error occurred\n");
+                exit(1);
+        }
+
+        g_option_context_free(context);
+
+        if (option_version == TRUE) {
+                g_print("%s\n", VERSION);
+                exit(EXIT_SUCCESS);
+        }
+
+        main_loop = g_main_loop_new(NULL, FALSE);
+
+        test_list = NULL;
+        test_current = NULL;
+}
+
+int tester_run(void)
+{
+        guint signal;
+        int ret;
+
+        if (!main_loop)
+                return EXIT_FAILURE;
+
+        if (option_list) {
+                g_main_loop_unref(main_loop);
+                return EXIT_SUCCESS;
+        }
+
+        signal = setup_signalfd();
+
+        g_idle_add(start_tester, NULL);
+        g_main_loop_run(main_loop);
+
+        g_source_remove(signal);
+
+        g_main_loop_unref(main_loop);
+
+        ret = tester_summarize();
+
+        g_list_free_full(test_list, test_destroy);
+
+        return ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tools/tester.h
+++ b/tools/tester.h
@@ -1,0 +1,77 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <stdbool.h>
+
+void tester_init(int *argc, char ***argv);
+int tester_run(void);
+
+bool tester_use_quiet(void);
+bool tester_use_debug(void);
+
+void tester_print(const char *format, ...)
+                                __attribute__((format(printf, 1, 2)));
+void tester_warn(const char *format, ...)
+                                __attribute__((format(printf, 1, 2)));
+void tester_debug(const char *format, ...)
+                                __attribute__((format(printf, 1, 2)));
+
+typedef void (*tester_destroy_func_t)(void *user_data);
+typedef void (*tester_data_func_t)(const void *test_data);
+
+void tester_add_full(const char *name, const void *test_data,
+                                tester_data_func_t pre_setup_func,
+                                tester_data_func_t setup_func,
+                                tester_data_func_t test_func,
+                                tester_data_func_t teardown_func,
+                                tester_data_func_t post_teardown_func,
+                                unsigned int timeout,
+                                void *user_data, tester_destroy_func_t destroy);
+
+void tester_add(const char *name, const void *test_data,
+                                        tester_data_func_t setup_func,
+                                        tester_data_func_t test_func,
+                                        tester_data_func_t teardown_func);
+
+void *tester_get_data(void);
+
+void tester_pre_setup_complete(void);
+void tester_pre_setup_failed(void);
+
+void tester_setup_complete(void);
+void tester_setup_failed(void);
+
+void tester_test_passed(void);
+void tester_test_failed(void);
+void tester_test_abort(void);
+
+void tester_teardown_complete(void);
+void tester_teardown_failed(void);
+
+void tester_post_teardown_complete(void);
+void tester_post_teardown_failed(void);
+
+typedef void (*tester_wait_func_t)(void *user_data);
+
+void tester_wait(unsigned int seconds, tester_wait_func_t func,
+                                                        void *user_data);

--- a/tools/util.c
+++ b/tools/util.c
@@ -1,0 +1,153 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <limits.h>
+#include <string.h>
+
+#include "util.h"
+
+void *btd_malloc(size_t size)
+{
+        if (__builtin_expect(!!size, 1)) {
+                void *ptr;
+
+                ptr = malloc(size);
+                if (ptr)
+                        return ptr;
+
+                fprintf(stderr, "failed to allocate %zu bytes\n", size);
+                abort();
+        }
+
+        return NULL;
+}
+
+void util_debug(util_debug_func_t function, void *user_data,
+                                                const char *format, ...)
+{
+        char str[78];
+        va_list ap;
+
+        if (!function || !format)
+                return;
+
+        va_start(ap, format);
+        vsnprintf(str, sizeof(str), format, ap);
+        va_end(ap);
+
+        function(str, user_data);
+}
+
+void util_hexdump(const char dir, const unsigned char *buf, size_t len,
+                                util_debug_func_t function, void *user_data)
+{
+        static const char hexdigits[] = "0123456789abcdef";
+        char str[68];
+        size_t i;
+
+        if (!function || !len)
+                return;
+
+        str[0] = dir;
+
+        for (i = 0; i < len; i++) {
+                str[((i % 16) * 3) + 1] = ' ';
+                str[((i % 16) * 3) + 2] = hexdigits[buf[i] >> 4];
+                str[((i % 16) * 3) + 3] = hexdigits[buf[i] & 0xf];
+                str[(i % 16) + 51] = isprint(buf[i]) ? buf[i] : '.';
+
+                if ((i + 1) % 16 == 0) {
+                        str[49] = ' ';
+                        str[50] = ' ';
+                        str[67] = '\0';
+                        function(str, user_data);
+                        str[0] = ' ';
+                }
+        }
+
+        if (i % 16 > 0) {
+                size_t j;
+                for (j = (i % 16); j < 16; j++) {
+                        str[(j * 3) + 1] = ' ';
+                        str[(j * 3) + 2] = ' ';
+                        str[(j * 3) + 3] = ' ';
+                        str[j + 51] = ' ';
+                }
+                str[49] = ' ';
+                str[50] = ' ';
+                str[67] = '\0';
+                function(str, user_data);
+        }
+}
+
+/* Helper for getting the dirent type in case readdir returns DT_UNKNOWN */
+unsigned char util_get_dt(const char *parent, const char *name)
+{
+        char filename[PATH_MAX];
+        struct stat st;
+
+        snprintf(filename, sizeof(filename), "%s/%s", parent, name);
+        if (lstat(filename, &st) == 0 && S_ISDIR(st.st_mode))
+                return DT_DIR;
+
+        return DT_UNKNOWN;
+}
+
+/* Helpers for bitfield operations */
+
+/* Find unique id in range from 1 to max but no bigger then
+ * sizeof(int) * 8. ffs() is used since it is POSIX standard
+ */
+uint8_t util_get_uid(unsigned int *bitmap, uint8_t max)
+{
+        uint8_t id;
+
+        id = ffs(~*bitmap);
+
+        if (!id || id > max)
+                return 0;
+
+        *bitmap |= 1 << (id - 1);
+
+        return id;
+}
+
+/* Clear id bit in bitmap */
+void util_clear_uid(unsigned int *bitmap, uint8_t id)
+{
+        if (!id)
+                return;
+
+        *bitmap &= ~(1 << (id - 1));
+}

--- a/tools/util.h
+++ b/tools/util.h
@@ -1,0 +1,179 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2012-2014  Intel Corporation. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <alloca.h>
+#include <byteswap.h>
+#include <string.h>
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define le16_to_cpu(val) (val)
+#define le32_to_cpu(val) (val)
+#define le64_to_cpu(val) (val)
+#define cpu_to_le16(val) (val)
+#define cpu_to_le32(val) (val)
+#define cpu_to_le64(val) (val)
+#define be16_to_cpu(val) bswap_16(val)
+#define be32_to_cpu(val) bswap_32(val)
+#define be64_to_cpu(val) bswap_64(val)
+#define cpu_to_be16(val) bswap_16(val)
+#define cpu_to_be32(val) bswap_32(val)
+#define cpu_to_be64(val) bswap_64(val)
+#elif __BYTE_ORDER == __BIG_ENDIAN
+#define le16_to_cpu(val) bswap_16(val)
+#define le32_to_cpu(val) bswap_32(val)
+#define le64_to_cpu(val) bswap_64(val)
+#define cpu_to_le16(val) bswap_16(val)
+#define cpu_to_le32(val) bswap_32(val)
+#define cpu_to_le64(val) bswap_64(val)
+#define be16_to_cpu(val) (val)
+#define be32_to_cpu(val) (val)
+#define be64_to_cpu(val) (val)
+#define cpu_to_be16(val) (val)
+#define cpu_to_be32(val) (val)
+#define cpu_to_be64(val) (val)
+#else
+#error "Unknown byte order"
+#endif
+
+#define get_unaligned(ptr)                      \
+__extension__ ({                                \
+        struct __attribute__((packed)) {        \
+                __typeof__(*(ptr)) __v;         \
+        } *__p = (__typeof__(__p)) (ptr);       \
+        __p->__v;                               \
+})
+
+#define put_unaligned(val, ptr)                 \
+do {                                            \
+        struct __attribute__((packed)) {        \
+                __typeof__(*(ptr)) __v;         \
+        } *__p = (__typeof__(__p)) (ptr);       \
+        __p->__v = (val);                       \
+} while (0)
+
+#define PTR_TO_UINT(p) ((unsigned int) ((uintptr_t) (p)))
+#define UINT_TO_PTR(u) ((void *) ((uintptr_t) (u)))
+
+#define PTR_TO_INT(p) ((int) ((intptr_t) (p)))
+#define INT_TO_PTR(u) ((void *) ((intptr_t) (u)))
+
+#define new0(type, count)                       \
+        (type *) (__extension__ ({              \
+                size_t __n = (size_t) (count);  \
+                size_t __s = sizeof(type);      \
+                void *__p;                      \
+                __p = btd_malloc(__n * __s);    \
+                memset(__p, 0, __n * __s);      \
+                __p;                            \
+        }))
+
+#define newa(t, n) ((t*) alloca(sizeof(t)*(n)))
+#define malloc0(n) (calloc((n), 1))
+
+void *btd_malloc(size_t size);
+
+typedef void (*util_debug_func_t)(const char *str, void *user_data);
+
+void util_debug(util_debug_func_t function, void *user_data,
+                                                const char *format, ...)
+                                        __attribute__((format(printf, 3, 4)));
+
+void util_hexdump(const char dir, const unsigned char *buf, size_t len,
+                                util_debug_func_t function, void *user_data);
+
+unsigned char util_get_dt(const char *parent, const char *name);
+
+uint8_t util_get_uid(unsigned int *bitmap, uint8_t max);
+void util_clear_uid(unsigned int *bitmap, uint8_t id);
+
+static inline int8_t get_s8(const void *ptr)
+{
+        return *((int8_t *) ptr);
+}
+
+static inline uint8_t get_u8(const void *ptr)
+{
+        return *((uint8_t *) ptr);
+}
+
+static inline uint16_t get_le16(const void *ptr)
+{
+        return le16_to_cpu(get_unaligned((const uint16_t *) ptr));
+}
+
+static inline uint16_t get_be16(const void *ptr)
+{
+        return be16_to_cpu(get_unaligned((const uint16_t *) ptr));
+}
+
+static inline uint32_t get_le32(const void *ptr)
+{
+        return le32_to_cpu(get_unaligned((const uint32_t *) ptr));
+}
+
+static inline uint32_t get_be32(const void *ptr)
+{
+        return be32_to_cpu(get_unaligned((const uint32_t *) ptr));
+}
+
+static inline uint64_t get_le64(const void *ptr)
+{
+        return le64_to_cpu(get_unaligned((const uint64_t *) ptr));
+}
+
+static inline uint64_t get_be64(const void *ptr)
+{
+        return be64_to_cpu(get_unaligned((const uint64_t *) ptr));
+}
+
+static inline void put_le16(uint16_t val, void *dst)
+{
+        put_unaligned(cpu_to_le16(val), (uint16_t *) dst);
+}
+
+static inline void put_be16(uint16_t val, const void *ptr)
+{
+        put_unaligned(cpu_to_be16(val), (uint16_t *) ptr);
+}
+
+static inline void put_le32(uint32_t val, void *dst)
+{
+        put_unaligned(cpu_to_le32(val), (uint32_t *) dst);
+}
+
+static inline void put_be32(uint32_t val, void *dst)
+{
+        put_unaligned(cpu_to_be32(val), (uint32_t *) dst);
+}
+
+static inline void put_le64(uint64_t val, void *dst)
+{
+        put_unaligned(cpu_to_le64(val), (uint64_t *) dst);
+}
+
+static inline void put_be64(uint64_t val, void *dst)
+{
+        put_unaligned(cpu_to_be64(val), (uint64_t *) dst);
+}


### PR DESCRIPTION
Most of this code is shamelessly stolen from BlueZ. 

The first patch adds the getopt parser to allow to add an additional path to lookup. Since the current code uses the static firmware table I shortcutted it a bit with my solution. Looks quite ugly but I didn't find any easy way. Otherwise the whole table code needs to be touched. 

The second patch adds the test-runner. I removed a bunch of code from test-runner, the rest is an exact copy from BlueZ excapt tab to spaces conversion. I tried also to add configure option to disable the build of it.

Overall I think it should be possible to get more of the use cases coverd by this time framework, especially the tentative test. Also some of the timeout use case are of interest.

