### PR TITLE
test-runner: cleanups and a bunch fo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 /test-api
 /test-basic
+
+/firmware_tester
+/test-runner

--- a/tools/firmware-tester.c
+++ b/tools/firmware-tester.c
@@ -1,3 +1,26 @@
+/*
+ *
+ *  firmwared - Linux Firmware Loader Daemon
+ *
+ *  Copyright (C) 2016  BMW Car IT GmbH.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/tools/firmware-tester.c
+++ b/tools/firmware-tester.c
@@ -439,6 +439,7 @@ static void test_firmware_load(const void *test_data) {
         if (!check_content(TEST_FIRMWARE_DEV, user->cfg->content)) {
                 tester_warn("content is not matching");
                 tester_test_failed();
+                return;
         }
 
         tester_test_passed();

--- a/tools/firmware-tester.c
+++ b/tools/firmware-tester.c
@@ -320,8 +320,6 @@ static bool check_content(const char *filename, const char *content) {
         return !strcmp(buf, content);
 }
 
-static pid_t daemon_pid = -1;
-
 static void daemon_callback(pid_t pid, int status, void *user_data)
 {
         if (WIFEXITED(status))
@@ -342,12 +340,6 @@ static const char *daemon_table[] = {
         "/usr/sbin/firmwared",
         NULL
 };
-
-static void teardown_daemon(void) {
-        if (daemon_pid > 0)
-                kill(daemon_pid, SIGTERM);
-        daemon_pid = -1;
-}
 
 static pid_t run_daemon(const char *path, bool tentative) {
         const char *home;
@@ -481,7 +473,7 @@ static void test_tentative_daemon_reload(void *user_data) {
         struct user_data *user = user_data;
 
         tester_debug("kill daemon");
-        teardown_daemon();
+        kill(user->pid, SIGTERM);
         setup_firmware_files(&cfg_tentative);
 
         tester_debug("restart daemon in non tentative mode");

--- a/tools/test-runner.c
+++ b/tools/test-runner.c
@@ -280,7 +280,7 @@ static void run_command(char *cmdname, char *home)
 {
         char *argv[9], *envp[3];
         int pos = 0, idx = 0;
-        pid_t pid, daemon_pid;
+        pid_t pid;
 
 start_next:
         if (run_auto) {
@@ -371,11 +371,6 @@ start_next:
                                                 corpse, WSTOPSIG(status));
                 else if (WIFCONTINUED(status))
                         printf("Process %d continued\n", corpse);
-
-                if (corpse == daemon_pid) {
-                        printf("firmware daemon terminated\n");
-                        daemon_pid = -1;
-                }
 
                 if (corpse == pid)
                         break;


### PR DESCRIPTION
As usual as soon one thinks the job is done, new stuff pops up.

- add a copyright header to the tools sources
- remove some leftovers 
- really kill the tentative daemon